### PR TITLE
feat: add data source history

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,7 +32,6 @@
     "react-hook-form": "^7.64.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7",
     "zod": "^4.1.12"
   },
   "devDependencies": {
@@ -44,6 +43,7 @@
     "eslint": "^9.36.0",
     "eslint-config-next": "15.2.1",
     "tailwindcss": "^4",
+    "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,10 +14,10 @@
     "@icons-pack/react-simple-icons": "^13.8.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
-    "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.7",
-    "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@repo/shared": "*",
     "class-variance-authority": "^0.7.1",
@@ -29,11 +29,11 @@
     "next-themes": "^0.4.6",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-hook-form": "^7.63.0",
+    "react-hook-form": "^7.64.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.1.11"
+    "zod": "^4.1.12"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,6 +1,5 @@
 @import "tailwindcss";
-
-@plugin "tailwindcss-animate";
+@import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -8,6 +8,14 @@
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
   --font-serif: var(--font-domine);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar: var(--sidebar);
 }
 
 :root {

--- a/apps/web/src/components/copy-text-button.tsx
+++ b/apps/web/src/components/copy-text-button.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+  ComponentProps,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { Button } from "./ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+
+interface CopyTextButtonProps {
+  text: string;
+  children: ReactNode;
+  tooltipText?: string;
+  buttonProps?: ComponentProps<typeof Button>;
+  clicked?: { tooltipText: string; children: ReactNode };
+}
+
+export function CopyTextButton({
+  text,
+  children,
+  tooltipText,
+  buttonProps,
+  clicked,
+}: CopyTextButtonProps) {
+  const [wasClicked, setWasClicked] = useState(false);
+
+  useEffect(() => {
+    if (!wasClicked) return;
+
+    setTimeout(() => {
+      setWasClicked(false);
+    }, 2000);
+  }, [wasClicked]);
+
+  const copyToClipboard = useCallback((text: string) => {
+    navigator.clipboard.writeText(text);
+    setWasClicked(true);
+  }, []);
+
+  const changeToClickedState = useMemo(
+    () => !!clicked && wasClicked,
+    [clicked, wasClicked]
+  );
+
+  const buttonContent = useMemo(() => {
+    return (
+      <Button onClick={() => copyToClipboard(text)} {...buttonProps}>
+        {changeToClickedState ? clicked!.children : children}
+      </Button>
+    );
+  }, [
+    buttonProps,
+    changeToClickedState,
+    clicked,
+    children,
+    copyToClipboard,
+    text,
+  ]);
+
+  const tooltipTextToShow = useMemo(
+    () => (changeToClickedState ? clicked!.tooltipText : tooltipText),
+    [changeToClickedState, clicked, tooltipText]
+  );
+
+  if (!tooltipText) {
+    return buttonContent;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{buttonContent}</TooltipTrigger>
+      <TooltipContent>{tooltipTextToShow}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/web/src/components/copy-text-button.tsx
+++ b/apps/web/src/components/copy-text-button.tsx
@@ -49,7 +49,7 @@ export function CopyTextButton({
   const buttonContent = useMemo(() => {
     return (
       <Button onClick={() => copyToClipboard(text)} {...buttonProps}>
-        {changeToClickedState ? clicked!.children : children}
+          {changeToClickedState ? clicked!.children : children}
       </Button>
     );
   }, [

--- a/apps/web/src/components/data-source-history-item.tsx
+++ b/apps/web/src/components/data-source-history-item.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { CopyIcon } from "lucide-react";
+import { Button } from "./ui/button";
+
+interface DataSourceHistoryItemProps {
+  dataSourceId: string;
+}
+
+export function DataSourceHistoryItem({
+  dataSourceId,
+}: DataSourceHistoryItemProps) {
+  return (
+    <li className="flex justify-between p-4">
+      {dataSourceId}
+      <Button variant="ghost" size="icon">
+        <CopyIcon />
+      </Button>
+    </li>
+  );
+}

--- a/apps/web/src/components/data-source-history-item.tsx
+++ b/apps/web/src/components/data-source-history-item.tsx
@@ -22,9 +22,12 @@ export function DataSourceHistoryItem({
             text={dataSourceId}
             tooltipText="Copiar ID da fonte de dados"
             buttonProps={{ variant: "ghost", size: "icon" }}
-            clicked={{ tooltipText: "Copiado!", children: <CheckIcon /> }}
+            clicked={{
+              tooltipText: "Copiado!",
+              children: <CheckIcon className="animate-in fade-in zoom-in" />,
+            }}
           >
-            <CopyIcon />
+            <CopyIcon className="animate-in fade-in zoom-in" />
           </CopyTextButton>
         </ItemActions>
       </Item>

--- a/apps/web/src/components/data-source-history-item.tsx
+++ b/apps/web/src/components/data-source-history-item.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { CopyIcon } from "lucide-react";
-import { Button } from "./ui/button";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { Item, ItemActions, ItemContent, ItemTitle } from "./ui/item";
+import { CopyTextButton } from "./copy-text-button";
 
 interface DataSourceHistoryItemProps {
   dataSourceId: string;
@@ -11,11 +12,22 @@ export function DataSourceHistoryItem({
   dataSourceId,
 }: DataSourceHistoryItemProps) {
   return (
-    <li className="flex justify-between p-4">
-      {dataSourceId}
-      <Button variant="ghost" size="icon">
-        <CopyIcon />
-      </Button>
+    <li>
+      <Item variant="outline">
+        <ItemContent>
+          <ItemTitle>{dataSourceId}</ItemTitle>
+        </ItemContent>
+        <ItemActions>
+          <CopyTextButton
+            text={dataSourceId}
+            tooltipText="Copiar ID da fonte de dados"
+            buttonProps={{ variant: "ghost", size: "icon" }}
+            clicked={{ tooltipText: "Copiado!", children: <CheckIcon /> }}
+          >
+            <CopyIcon />
+          </CopyTextButton>
+        </ItemActions>
+      </Item>
     </li>
   );
 }

--- a/apps/web/src/components/notion-data-source-form.tsx
+++ b/apps/web/src/components/notion-data-source-form.tsx
@@ -21,6 +21,8 @@ import { useState } from "react";
 import LoadingButton from "./loading-button";
 import { sendStockMessage } from "@/app/actions/channel";
 import { showErrorToast, showToast } from "@/utils/toast";
+import { appendToLocalStorageArray } from "@/utils/local-storage";
+import { DATA_SOURCE_HISTORY_KEY } from "@/constants/local-storage";
 
 interface NotionDataSourceFormProps {
   className?: string;
@@ -42,6 +44,7 @@ export default function NotionDataSourceForm({
       setIsLoading(true);
       const actionResult = await sendStockMessage(data);
       if (actionResult.success) {
+        appendToLocalStorageArray(DATA_SOURCE_HISTORY_KEY, data.dataSourceId);
         showToast("Atualização requisitada com sucesso");
       } else {
         showErrorToast("Um erro ocorreu", actionResult.error);

--- a/apps/web/src/components/notion-data-source-history.tsx
+++ b/apps/web/src/components/notion-data-source-history.tsx
@@ -15,8 +15,8 @@ export function NotionDataSourceHistory() {
   }, []);
 
   return (
-    <div>
-      <span className="inline-flex gap-1 items-center text-muted-foreground">
+    <div className="flex flex-col gap-4">
+      <span className="inline-flex gap-1 items-center">
         <HistoryIcon size={18} />
         <h3>Historico</h3>
       </span>

--- a/apps/web/src/components/notion-data-source-history.tsx
+++ b/apps/web/src/components/notion-data-source-history.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { DATA_SOURCE_HISTORY_KEY } from "@/constants/local-storage";
+import { getLocalStorage } from "@/utils/local-storage";
+import { HistoryIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { DataSourceHistoryItem } from "./data-source-history-item";
+
+export function NotionDataSourceHistory() {
+  const [history, setHistory] = useState<string[] | null>([]);
+
+  useEffect(() => {
+    const storedOrder = getLocalStorage<string[]>(DATA_SOURCE_HISTORY_KEY);
+    setHistory(storedOrder);
+  }, []);
+
+  return (
+    <div>
+      <span className="inline-flex gap-1 items-center text-muted-foreground">
+        <HistoryIcon size={18} />
+        <h3>Historico</h3>
+      </span>
+      {history ? (
+        <ul className="flex flex-col divide-y">
+          {history.map((dataSourceId) => (
+            <DataSourceHistoryItem
+              key={dataSourceId}
+              dataSourceId={dataSourceId}
+            />
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground mt-2">
+          Não há histórico de fontes de dados.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/section-item.tsx
+++ b/apps/web/src/components/section-item.tsx
@@ -6,7 +6,6 @@ import {
   DEFAULT_NOTION_DATA_SOURCE_SECTION_KEY,
   DEFAULT_NOTION_SETTINGS_SECTION_KEY,
 } from "@/constants";
-import NotionDataSourceForm from "./notion-data-source-form";
 import SectionWrapper from "./section-wrapper";
 import { BookOpenIcon, CircleHelpIcon, SettingsIcon } from "lucide-react";
 import NotionSettingsForm from "./notion-settings-form";
@@ -15,6 +14,7 @@ import { DragControls, Reorder, useDragControls } from "motion/react";
 import { OrderKeys } from "@/types/order";
 import { ReactNode } from "react";
 import FaqSection from "./faq-section";
+import { UpdateNotionSection } from "./update-notion-section";
 
 interface SectionConfig {
   title: string;
@@ -28,7 +28,7 @@ const SECTIONS_CONFIG: Record<OrderKeys, SectionConfig> = {
     title: "Fonte de dados do Notion",
     collapsible: false,
     icon: null,
-    component: NotionDataSourceForm,
+    component: UpdateNotionSection,
   },
   [DEFAULT_NOTION_SETTINGS_SECTION_KEY]: {
     title: "Configuração dos campos",

--- a/apps/web/src/components/ui/accordion.tsx
+++ b/apps/web/src/components/ui/accordion.tsx
@@ -1,15 +1,15 @@
-"use client";
+"use client"
 
-import * as React from "react";
-import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDownIcon } from "lucide-react";
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDownIcon } from "lucide-react"
 
-import { cn } from "@/utils/tailwind";
+import { cn } from "@/utils/tailwind"
 
 function Accordion({
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Root>) {
-  return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+  return <AccordionPrimitive.Root data-slot="accordion" {...props} />
 }
 
 function AccordionItem({
@@ -22,13 +22,12 @@ function AccordionItem({
       className={cn("border-b last:border-b-0", className)}
       {...props}
     />
-  );
+  )
 }
 
 function AccordionTrigger({
   className,
   children,
-  disabled,
   ...props
 }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
   return (
@@ -36,19 +35,16 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          "ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all focus-visible:ring-4 focus-visible:outline-1 disabled:pointer-events-none [&[data-state=open]>svg]:rotate-180",
+          "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-md py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
           className
         )}
-        disabled={disabled}
         {...props}
       >
         {children}
-        {!disabled && (
-          <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
-        )}
+        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
-  );
+  )
 }
 
 function AccordionContent({
@@ -64,7 +60,7 @@ function AccordionContent({
     >
       <div className={cn("pt-0 pb-4", className)}>{children}</div>
     </AccordionPrimitive.Content>
-  );
+  )
 }
 
-export { Accordion, AccordionItem, AccordionTrigger, AccordionContent };
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
-          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+          "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
           "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -5,26 +5,28 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/utils/tailwind"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md px-3 has-[>svg]:px-2.5",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        "icon-sm": "size-8",
+        "icon-lg": "size-10",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -19,7 +19,10 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
-      className={cn("flex flex-col gap-1.5 px-6", className)}
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
       {...props}
     />
   )
@@ -45,6 +48,19 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -59,10 +75,18 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6", className)}
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
       {...props}
     />
   )
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/apps/web/src/components/ui/form.tsx
+++ b/apps/web/src/components/ui/form.tsx
@@ -5,12 +5,12 @@ import * as LabelPrimitive from "@radix-ui/react-label"
 import { Slot } from "@radix-ui/react-slot"
 import {
   Controller,
-  ControllerProps,
-  FieldPath,
-  FieldValues,
   FormProvider,
   useFormContext,
   useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
 } from "react-hook-form"
 
 import { cn } from "@/utils/tailwind"
@@ -80,7 +80,7 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
     <FormItemContext.Provider value={{ id }}>
       <div
         data-slot="form-item"
-        className={cn("grid gap-3", className)}
+        className={cn("grid gap-2", className)}
         {...props}
       />
     </FormItemContext.Provider>
@@ -97,7 +97,7 @@ function FormLabel({
     <Label
       data-slot="form-label"
       data-error={!!error}
-      className={cn("data-[error=true]:text-destructive-foreground font-bold", className)}
+      className={cn("data-[error=true]:text-destructive", className)}
       htmlFor={formItemId}
       {...props}
     />
@@ -137,7 +137,7 @@ function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
 
 function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
   const { error, formMessageId } = useFormField()
-  const body = error ? String(error?.message) : props.children
+  const body = error ? String(error?.message ?? "") : props.children
 
   if (!body) {
     return null
@@ -147,7 +147,7 @@ function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="form-message"
       id={formMessageId}
-      className={cn("text-destructive-foreground text-sm", className)}
+      className={cn("text-destructive text-sm", className)}
       {...props}
     >
       {body}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/apps/web/src/components/ui/item.tsx
+++ b/apps/web/src/components/ui/item.tsx
@@ -1,0 +1,193 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/utils/tailwind"
+import { Separator } from "@/components/ui/separator"
+
+function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      role="list"
+      data-slot="item-group"
+      className={cn("group/item-group flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      className={cn("my-0", className)}
+      {...props}
+    />
+  )
+}
+
+const itemVariants = cva(
+  "group/item flex items-center border border-transparent text-sm rounded-md transition-colors [a]:hover:bg-accent/50 [a]:transition-colors duration-100 flex-wrap outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border-border",
+        muted: "bg-muted/50",
+      },
+      size: {
+        default: "p-4 gap-4 ",
+        sm: "py-3 px-4 gap-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Item({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof itemVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div"
+  return (
+    <Comp
+      data-slot="item"
+      data-variant={variant}
+      data-size={size}
+      className={cn(itemVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none group-has-[[data-slot=item-description]]/item:translate-y-0.5",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "size-8 border rounded-sm bg-muted [&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 rounded-sm overflow-hidden [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function ItemMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemMediaVariants>) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-content"
+      className={cn(
+        "flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-title"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="item-description"
+      className={cn(
+        "text-muted-foreground line-clamp-2 text-sm leading-normal font-normal text-balance",
+        "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-actions"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-header"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-footer"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemActions,
+  ItemGroup,
+  ItemSeparator,
+  ItemTitle,
+  ItemDescription,
+  ItemHeader,
+  ItemFooter,
+}

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
     <LabelPrimitive.Root
       data-slot="label"
       className={cn(
-        "text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -13,7 +13,7 @@ function Separator({
 }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
   return (
     <SeparatorPrimitive.Root
-      data-slot="separator-root"
+      data-slot="separator"
       decorative={decorative}
       orientation={orientation}
       className={cn(

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { VariantProps, cva } from "class-variance-authority"
+import { cva, VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
@@ -32,7 +32,7 @@ const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
-type SidebarContext = {
+type SidebarContextProps = {
   state: "expanded" | "collapsed"
   open: boolean
   setOpen: (open: boolean) => void
@@ -42,7 +42,7 @@ type SidebarContext = {
   toggleSidebar: () => void
 }
 
-const SidebarContext = React.createContext<SidebarContext | null>(null)
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
 
 function useSidebar() {
   const context = React.useContext(SidebarContext)
@@ -113,7 +113,7 @@ function SidebarProvider({
   // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed"
 
-  const contextValue = React.useMemo<SidebarContext>(
+  const contextValue = React.useMemo<SidebarContextProps>(
     () => ({
       state,
       open,
@@ -183,10 +183,6 @@ function Sidebar({
   if (isMobile) {
     return (
       <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
-        <SheetHeader className="sr-only">
-          <SheetTitle>Sidebar</SheetTitle>
-          <SheetDescription>Displays the mobile sidebar.</SheetDescription>
-        </SheetHeader>
         <SheetContent
           data-sidebar="sidebar"
           data-slot="sidebar"
@@ -199,6 +195,10 @@ function Sidebar({
           }
           side={side}
         >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
           <div className="flex h-full w-full flex-col">{children}</div>
         </SheetContent>
       </Sheet>
@@ -216,8 +216,9 @@ function Sidebar({
     >
       {/* This is what handles the sidebar gap on desktop */}
       <div
+        data-slot="sidebar-gap"
         className={cn(
-          "relative h-svh w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -226,6 +227,7 @@ function Sidebar({
         )}
       />
       <div
+        data-slot="sidebar-container"
         className={cn(
           "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
@@ -241,6 +243,7 @@ function Sidebar({
       >
         <div
           data-sidebar="sidebar"
+          data-slot="sidebar-inner"
           className="bg-sidebar group-data-[variant=floating]:border-sidebar-border flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:shadow-sm"
         >
           {children}
@@ -263,7 +266,7 @@ function SidebarTrigger({
       data-slot="sidebar-trigger"
       variant="ghost"
       size="icon"
-      className={cn("h-7 w-7", className)}
+      className={cn("size-7", className)}
       onClick={(event) => {
         onClick?.(event)
         toggleSidebar()
@@ -306,8 +309,8 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex min-h-svh flex-1 flex-col",
-        "peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "bg-background relative flex w-full flex-1 flex-col",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-primary/10 animate-pulse rounded-md", className)}
+      className={cn("bg-accent animate-pulse rounded-md", className)}
       {...props}
     />
   )

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -10,17 +10,13 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
-      toastOptions={{
-        classNames: {
-          toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
-          actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground font-medium",
-          cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground font-medium",
-        },
-      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
       {...props}
     />
   )

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -36,7 +36,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 4,
+  sideOffset = 0,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -46,13 +46,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-w-sm rounded-md px-3 py-1.5 text-xs",
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/apps/web/src/components/update-notion-section.tsx
+++ b/apps/web/src/components/update-notion-section.tsx
@@ -1,0 +1,11 @@
+import NotionDataSourceForm from "./notion-data-source-form";
+import { NotionDataSourceHistory } from "./notion-data-source-history";
+
+export function UpdateNotionSection() {
+  return (
+    <div className="flex flex-col">
+      <NotionDataSourceForm />
+      <NotionDataSourceHistory />
+    </div>
+  )
+}

--- a/apps/web/src/constants/local-storage.ts
+++ b/apps/web/src/constants/local-storage.ts
@@ -1,2 +1,3 @@
 export const NOTION_FIELDS_MAPPING_KEY = "notionFieldsMapping";
-export const SECTIONS_ORDER_KEY = "sectionsOrder"; 
+export const SECTIONS_ORDER_KEY = "sectionsOrder";
+export const DATA_SOURCE_HISTORY_KEY = "dataSourceHistory";

--- a/apps/web/src/utils/local-storage.ts
+++ b/apps/web/src/utils/local-storage.ts
@@ -9,3 +9,19 @@ export function setLocalStorage(key: string, value: unknown) {
   const notionFieldsMapping = JSON.stringify(value);
   localStorage.setItem(key, notionFieldsMapping);
 }
+
+export function appendToLocalStorageArray<T>(
+  key: string,
+  newItem: T,
+  allowDuplicates: boolean = false
+) {
+  const currentArray = getLocalStorage<T[]>(key) || [];
+  if (!allowDuplicates && currentArray.includes(newItem)) return;
+
+  const updatedArray = [...currentArray, newItem];
+  setLocalStorage(key, updatedArray);
+}
+
+export function clearLocalStorage(key: string) {
+  localStorage.removeItem(key);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,6 @@
         "react-hook-form": "^7.64.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss-animate": "^1.0.7",
         "zod": "^4.1.12"
       },
       "devDependencies": {
@@ -77,6 +76,7 @@
         "eslint": "^9.36.0",
         "eslint-config-next": "15.2.1",
         "tailwindcss": "^4",
+        "tw-animate-css": "^1.4.0",
         "typescript": "^5.9.3"
       }
     },
@@ -8474,16 +8474,8 @@
       "version": "4.1.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
+      "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tailwindcss-animate": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
-      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -8805,6 +8797,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
+      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,10 +47,10 @@
         "@icons-pack/react-simple-icons": "^13.8.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
-        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-separator": "^1.1.7",
-        "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@repo/shared": "*",
         "class-variance-authority": "^0.7.1",
@@ -62,11 +62,11 @@
         "next-themes": "^0.4.6",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-hook-form": "^7.63.0",
+        "react-hook-form": "^7.64.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^4.1.11"
+        "zod": "^4.1.12"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -7530,9 +7530,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.63.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
-      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "version": "7.64.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.64.0.tgz",
+      "integrity": "sha512-fnN+vvTiMLnRqKNTVhDysdrUay0kUUAymQnFIznmgDvapjveUWOOPqMNzPg+A+0yf9DuE2h6xzBjN1s+Qx8wcg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -9367,9 +9367,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+      "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
This pull request introduces a new Notion data source history feature, refactors the Notion data source section, and applies several UI improvements and dependency updates. The most significant changes are the addition of components to display and interact with a history of Notion data source IDs, updates to the UI component library for better accessibility and styling, and dependency upgrades for improved stability and features.

**New Notion Data Source History Feature:**

* Added `NotionDataSourceHistory` and `DataSourceHistoryItem` components to display and manage a local history of Notion data source IDs, with copy-to-clipboard functionality and tooltips for user feedback. (`apps/web/src/components/notion-data-source-history.tsx`, `apps/web/src/components/data-source-history-item.tsx`, `apps/web/src/components/copy-text-button.tsx`) [[1]](diffhunk://#diff-dcef51f0f229c9655952f9d126601d49d3b2d35c7a5e544c567bc19e7b040999R1-R39) [[2]](diffhunk://#diff-31b9cba9c7e90265d6ea3353d736f799fe556ed776a83c4ca27c52b24c5e0b07R1-R36) [[3]](diffhunk://#diff-17dcbb6fa3b035d5fc03f7c6854c12b4a1a25f12568eddb8f9a8d70b15e3537eR1-R79)
* Updated the Notion data source form to save submitted data source IDs to local storage for history tracking. (`apps/web/src/components/notion-data-source-form.tsx`) [[1]](diffhunk://#diff-e5c7d00218627c7f75e8e423f775675c19b58c775948d0a7be5b670d6c20930dR24-R25) [[2]](diffhunk://#diff-e5c7d00218627c7f75e8e423f775675c19b58c775948d0a7be5b670d6c20930dR47)
* Refactored the Notion data source section to use the new `UpdateNotionSection` component, integrating the history feature. (`apps/web/src/components/section-item.tsx`) [[1]](diffhunk://#diff-82650f560fa09b27bea6e6512a0c55a90f35d3f822dc3d3f0b824f80daf16be2L9) [[2]](diffhunk://#diff-82650f560fa09b27bea6e6512a0c55a90f35d3f822dc3d3f0b824f80daf16be2R17) [[3]](diffhunk://#diff-82650f560fa09b27bea6e6512a0c55a90f35d3f822dc3d3f0b824f80daf16be2L31-R31)

**UI Component Improvements:**

* Enhanced UI components (`button`, `badge`, `card`, `form`, `accordion`, `alert-dialog`) with better dark mode support, accessibility, and layout adjustments, including new variants and improved error styling. (`apps/web/src/components/ui/button.tsx`, `apps/web/src/components/ui/badge.tsx`, `apps/web/src/components/ui/card.tsx`, `apps/web/src/components/ui/form.tsx`, `apps/web/src/components/ui/accordion.tsx`, `apps/web/src/components/ui/alert-dialog.tsx`) [[1]](diffhunk://#diff-7eedccc2b49d7116e34e431c4d35c952723c7d4101de809118aeb956cf37a822L8-R29) [[2]](diffhunk://#diff-7d13f452a101fd74830056ff36861be7711cef615b51371dc287645206e50e6dL17-R17) [[3]](diffhunk://#diff-8b864df1da54856d65ab5e21d4cefd560efedd33093e1b9378e92bd082df0d6aL22-R25) [[4]](diffhunk://#diff-8b864df1da54856d65ab5e21d4cefd560efedd33093e1b9378e92bd082df0d6aR51-R63) [[5]](diffhunk://#diff-8b864df1da54856d65ab5e21d4cefd560efedd33093e1b9378e92bd082df0d6aL62-R92) [[6]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L8-R13) [[7]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L83-R83) [[8]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L100-R100) [[9]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L140-R140) [[10]](diffhunk://#diff-9ad6353b92c5d7f791ea81711c27e6edee0a6fb6f2d17ad5dd4720da077a7781L1-R12) [[11]](diffhunk://#diff-9ad6353b92c5d7f791ea81711c27e6edee0a6fb6f2d17ad5dd4720da077a7781L25-R47) [[12]](diffhunk://#diff-9ad6353b92c5d7f791ea81711c27e6edee0a6fb6f2d17ad5dd4720da077a7781L67-R66) [[13]](diffhunk://#diff-33c02a6236d51f1905be1d3e723565707bd844a3db7d57fee3e13f7d383f0fb6L39-R39)

**Dependency Updates:**

* Upgraded several dependencies in `package.json`, including Radix UI packages, `react-hook-form`, `zod`, and replaced `tailwindcss-animate` with `tw-animate-css` for improved animation support. (`apps/web/package.json`) [[1]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L17-R20) [[2]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L32-R35) [[3]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8R46)
* Updated global CSS imports to use the new animation library and added sidebar color variables for theme consistency. (`apps/web/src/app/globals.css`)

---

**Encoded references:**  
[[1]](diffhunk://#diff-dcef51f0f229c9655952f9d126601d49d3b2d35c7a5e544c567bc19e7b040999R1-R39) [[2]](diffhunk://#diff-31b9cba9c7e90265d6ea3353d736f799fe556ed776a83c4ca27c52b24c5e0b07R1-R36) [[3]](diffhunk://#diff-17dcbb6fa3b035d5fc03f7c6854c12b4a1a25f12568eddb8f9a8d70b15e3537eR1-R79) [[4]](diffhunk://#diff-e5c7d00218627c7f75e8e423f775675c19b58c775948d0a7be5b670d6c20930dR24-R25) [[5]](diffhunk://#diff-e5c7d00218627c7f75e8e423f775675c19b58c775948d0a7be5b670d6c20930dR47) [[6]](diffhunk://#diff-82650f560fa09b27bea6e6512a0c55a90f35d3f822dc3d3f0b824f80daf16be2L9) [[7]](diffhunk://#diff-82650f560fa09b27bea6e6512a0c55a90f35d3f822dc3d3f0b824f80daf16be2R17) [[8]](diffhunk://#diff-82650f560fa09b27bea6e6512a0c55a90f35d3f822dc3d3f0b824f80daf16be2L31-R31) [[9]](diffhunk://#diff-7eedccc2b49d7116e34e431c4d35c952723c7d4101de809118aeb956cf37a822L8-R29) [[10]](diffhunk://#diff-7d13f452a101fd74830056ff36861be7711cef615b51371dc287645206e50e6dL17-R17) [[11]](diffhunk://#diff-8b864df1da54856d65ab5e21d4cefd560efedd33093e1b9378e92bd082df0d6aL22-R25) [[12]](diffhunk://#diff-8b864df1da54856d65ab5e21d4cefd560efedd33093e1b9378e92bd082df0d6aR51-R63) [[13]](diffhunk://#diff-8b864df1da54856d65ab5e21d4cefd560efedd33093e1b9378e92bd082df0d6aL62-R92) [[14]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L8-R13) [[15]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L83-R83) [[16]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L100-R100) [[17]](diffhunk://#diff-793f2aff3a75317b9893a76655ef51d9d21a58693300b5f9e3e284d266ed2899L140-R140) [[18]](diffhunk://#diff-9ad6353b92c5d7f791ea81711c27e6edee0a6fb6f2d17ad5dd4720da077a7781L1-R12) [[19]](diffhunk://#diff-9ad6353b92c5d7f791ea81711c27e6edee0a6fb6f2d17ad5dd4720da077a7781L25-R47) [[20]](diffhunk://#diff-9ad6353b92c5d7f791ea81711c27e6edee0a6fb6f2d17ad5dd4720da077a7781L67-R66) [[21]](diffhunk://#diff-33c02a6236d51f1905be1d3e723565707bd844a3db7d57fee3e13f7d383f0fb6L39-R39) [[22]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L17-R20) [[23]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L32-R35) [[24]](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8R46) [[25]](diffhunk://#diff-9cb236306aa43941defe02ae95334afcf65f6ae9abb6f999a1b4451d02956550L2-R17)